### PR TITLE
enable global_scope fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Per Angusta Fork
+This is a fork adapted for the special use of Per Angusta.
+
 # EMobility i18n
 
 This gem provides some i18n functionality for the eMobility project.
@@ -57,11 +60,11 @@ I18n::Backend::Simple.send(:include, I18n::Backend::GlobalScope)
 ```
 
 After that you need to set `global_scope` just as you would set `default_locale`:
- 
+
 ``` ruby
 I18n.global_scope = 'some_scope'
 ```
-    
+
 If you want to scope by subdomain, you can put something like this in `app/controllers/application_controller.rb`:
 
 ``` ruby
@@ -76,11 +79,18 @@ class ApplicationController
 end
 ```
 
-Note: If you use a scope containing other scopes as global scope, the whole scope gets chopped off!
+Note: If you want to use global_scope fallbacks, you have to use Array format as follows
+
+``` ruby
+I18n.global_scope = %w[some scope]
+
+t('foo') # => looks for 'some.foo' and then 'scope.foo' and finally 'foo'
+```
+You can use scopes containing other scopes within the array form of global_scope too but the whole scope gets chopped off! Same as below:
 
 ``` ruby
 I18n.global_scope = 'some.scope'
-t('foo') # => looks for 'some.scope.foo' and then 'foo' but never 'some.foo'
+t('foo') # => looks for 'some.scope.foo' and then 'foo' but never 'scope.foo' nor 'some.foo'
 ```
 
 ### Global Scope Prefix
@@ -152,7 +162,8 @@ I18n.backend = I18n::Backend::EMobility.new
 ## Contributing
 
 1. Fork it ( http://github.com/<my-github-username>/emobility-i18n/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+2. Create your feature branch (`git checkout -b feature/name_your_feature`)
+3. Run tests locally, all examples should be green (`rspec`)
+4. Commit your changes (`git commit -am 'Add some feature'`)
+6. Push to the branch (`git push origin feature/name_your_feature`)
+7. Create new Pull Request

--- a/emobility-i18n.gemspec
+++ b/emobility-i18n.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cached_key_value_store"
   spec.add_runtime_dependency "redis"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "rspec"
 end

--- a/lib/emobility-i18n/backend/global_scope.rb
+++ b/lib/emobility-i18n/backend/global_scope.rb
@@ -10,9 +10,9 @@ module I18n
         return super if I18n.global_scope.nil?
 
         global_scopes = Array(I18n.global_scope)
-        separator = options[:separator] || I18n.default_separator
-        result = nil
-        scope ||= []
+        separator     = options[:separator] || I18n.default_separator
+        scope         = I18n.normalize_keys(nil, nil, scope, separator)
+        result        = nil
 
         until result || global_scopes.empty?
           scope.unshift(global_scopes.first.to_sym)

--- a/lib/emobility-i18n/backend/global_scope.rb
+++ b/lib/emobility-i18n/backend/global_scope.rb
@@ -9,18 +9,23 @@ module I18n
       def lookup(locale, key, scope = [], options = {})
         return super if I18n.global_scope.nil?
 
+        global_scopes = Array(I18n.global_scope)
         separator = options[:separator] || I18n.default_separator
-        scope = [I18n.global_scope.to_sym] + I18n.normalize_keys(nil, key, scope, separator)
-        key = (scope.slice!(-1,1) || []).join(separator)
+        result = nil
+        scope ||= []
 
-        result = super
-        unless result.nil?
-          result
-        else
+        until result || global_scopes.empty?
+          scope.unshift(global_scopes.first.to_sym)
+
+          result = super
+          next if result
+
           scope = scope.dup
           scope.shift
-          super
+          global_scopes.shift
         end
+
+        result || super
       end
 
       module ConfigExtension

--- a/spec/backend/emobility_key_value_spec.rb
+++ b/spec/backend/emobility_key_value_spec.rb
@@ -4,7 +4,9 @@ describe I18n::Backend::EMobilityKeyValue do
   let(:i18n_options) { {} }
 
   before do
-    I18n.backend = described_class.new(Redis.new)
+    # I18n.backend = described_class.new(Redis.new)
+    # temporary fix of specs because of this https://github.com/guilleiguaran/fakeredis/issues/213
+    I18n.backend = described_class.new({})
 
     store_translations(:en,
                        the_application: {

--- a/spec/backend/global_scope_spec.rb
+++ b/spec/backend/global_scope_spec.rb
@@ -48,4 +48,61 @@ describe I18n::Backend::GlobalScope do
       end
     end
   end
+
+  context 'when global scope array is given' do
+    let(:global_scope) { ['first_prefix', 'second_prefix'] }
+
+    before do
+      I18n.global_scope = global_scope
+    end
+
+    context 'when scoped key does not exist' do
+      before do
+        store_translations(:en, foo: 'foo')
+      end
+
+      it 'returns translation for unscoped key' do
+        expect(I18n.t('foo')).to eq 'foo'
+      end
+    end
+
+    context 'when both first scoped and not-scoped key exist' do
+      before do
+        store_translations(:en, global_scope[0] => { foo: 'prefixed_foo', bar: { baz: 'prefixed_baz' } },
+                                foo: 'foo',
+                                bar: { baz: 'baz' })
+      end
+
+      it 'returns translation for the first scoped key' do
+        expect(I18n.t('foo')).to eq 'prefixed_foo'
+        expect(I18n.t('bar.baz')).to eq 'prefixed_baz'
+      end
+    end
+
+    context 'when both second scoped and not-scoped key exist' do
+      before do
+        store_translations(:en, global_scope[1] => { foo: 'prefixed_foo', bar: { baz: 'prefixed_baz' } },
+                                foo: 'foo',
+                                bar: { baz: 'baz' })
+      end
+
+      it 'returns translation for second scoped key' do
+        expect(I18n.t('foo')).to eq 'prefixed_foo'
+        expect(I18n.t('bar.baz')).to eq 'prefixed_baz'
+      end
+    end
+    context 'when both first and second scoped and not-scoped key exist' do
+      before do
+        store_translations(:en, global_scope[0] => { foo: 'first_prefixed_foo', bar: { baz: 'first_prefixed_baz' } },
+                                global_scope[1] => { foo: 'prefixed_foo', bar: { baz: 'prefixed_baz' } },
+                                foo: 'foo',
+                                bar: { baz: 'baz' })
+      end
+
+      it 'returns translation for first scoped key' do
+        expect(I18n.t('foo')).to eq 'first_prefixed_foo'
+        expect(I18n.t('bar.baz')).to eq 'first_prefixed_baz'
+      end
+    end
+  end
 end


### PR DESCRIPTION
POC - Enable I18n.global_scope fallbacks

As a hospital user, I would like to have custom translations but also have standard Hospitals translations as fallbacks and then the standard ones at last.

Fallback mechanism for I18n.t('some_key'), with I18n.global_scope = [subdomain, 'hospital']

    Look for 'subdomain.some_key'
    if previous nil => look for 'hospital.some_key'
    if previous nil => look for 'some_key'